### PR TITLE
All TLDs for Google Scholar and not backend

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,9 +6,8 @@
 
   "content_scripts": [
     {
-      "matches": [
-        "https://scholar.google.co.uk/*"
-      ],
+      "matches":        ["https://*/*"],
+      "include_globs":  ["https://scholar.google.*/scholar?*"],
       "js": ["third-party/jquery-3.4.0.min.js", "content.js"]
     }
   ],


### PR DESCRIPTION
https://stackoverflow.com/questions/16186956/how-to-load-a-content-script-on-all-google-international-pages
for all TLDs, not just .co.uk.

And stops it from triggering on settings pages.